### PR TITLE
Update head.html

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,8 +37,10 @@
 
 {{ end }}
 
-<!-- Site Generator -->
-<meta name="generator" content="Hugo {{ .Hugo.Version }}">
+<!-- Hugo info -->
+{{ printf "<!--Hugo Build Date: %s-->" hugo.BuildDate | safeHTML }}
+{{ printf "<!--Hugo Commit Hash: %s-->" hugo.CommitHash | safeHTML }}
+{{ hugo.Generator }}
 
 <!-- Permalink & RSSlink -->
 <link rel="canonical" href="{{ .Permalink }}">

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -38,8 +38,6 @@
 {{ end }}
 
 <!-- Hugo info -->
-{{ printf "<!--Hugo Build Date: %s-->" hugo.BuildDate | safeHTML }}
-{{ printf "<!--Hugo Commit Hash: %s-->" hugo.CommitHash | safeHTML }}
 {{ hugo.Generator }}
 
 <!-- Permalink & RSSlink -->


### PR DESCRIPTION
To avoid this warning:
Building sites … WARN 2019/08/04 00:20:52 Page's .Hugo is deprecated and will be removed in a future release. Use the global hugo function.
This will be the new output, consider to include the Build Date and Commit Hash optionally:
<!-- Hugo info -->
<!--Hugo Build Date: 2019-04-08T17:03:33Z-->
<!--Hugo Commit Hash: 4333cc77f-->
<meta name="generator" content="Hugo 0.55.0" />