### PR TITLE
Remove Google+ share

### DIFF
--- a/layouts/post/summary.html
+++ b/layouts/post/summary.html
@@ -23,9 +23,6 @@
       <a class="share share-twitter" target="_blank" href="https://twitter.com/intent/tweet/?text={{ .Title }}&amp;url={{ .Permalink }}" title="Share on Twitter">
         <svg class="icon share-twitter-icon" fill="currentColor"><use xlink:href="#icon-twitter" /></svg>
       </a>
-      <a class="share share-google" target="_blank" href="https://plus.google.com/share?url={{ .Title }}&amp;url={{ .Permalink }}" title="Share on Google+">
-        <svg class="icon" fill="currentColor"><use xlink:href="#icon-googleplus" /></svg>
-      </a>
     </div>
   </footer>
 </article>


### PR DESCRIPTION
Google+ is no longer available for consumer (personal) and brand accounts